### PR TITLE
bump action from Node12 to Node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/action.yaml
+++ b/action.yaml
@@ -26,5 +26,5 @@ inputs:
     required: false
     default: 'approved'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

You can see more here: https://github.com/actions/setup-node/compare/v2.5.1...v3.0.0

Signed-off-by: Enes <ahmedenesturan@gmail.com>